### PR TITLE
Two things changed here.

### DIFF
--- a/RAPID/celery.py
+++ b/RAPID/celery.py
@@ -35,6 +35,8 @@ app.conf.update(
     #CELERY_TASK_SERIALIZER='json',
     #CELERY_RESULT_SERIALIZER='json',
     #CELERY_TIMEZONE='UTC',
+    # CELERY_ALWAYS_EAGER=True,
+    # TEST_RUNNER = 'djcelery.contrib.test_runner.CeleryTestSuiteRunner',
 )
 
 

--- a/RAPID/settings/base.py
+++ b/RAPID/settings/base.py
@@ -93,6 +93,7 @@ INSTALLED_APPS = (
     'profiles',
     'pivoteer',
     'monitors',
+    'tests',
 )
 
 

--- a/RAPID/settings/local.py
+++ b/RAPID/settings/local.py
@@ -6,6 +6,8 @@ TEMPLATE_DEBUG = True
 CSRF_COOKIE_SECURE = False
 SESSION_COOKIE_SECURE = False
 
+
+
 AMQP_URL = 'amqp://guest:guest@localhost:5672//'
 
 BASE_SITE_URL = 'http://0.0.0.0:8000'

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "RAPID.settings.production")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "RAPID.settings.local")
 
     from django.core.management import execute_from_command_line
 

--- a/pivoteer/models.py
+++ b/pivoteer/models.py
@@ -8,6 +8,8 @@ from django.db.models import Max, Min
 from django_pgjson.fields import JsonField
 from core.utilities import check_domain_valid, get_base_domain
 
+logger = logging.getLogger(None)
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -240,6 +242,7 @@ class IndicatorRecord(models.Model):
         return info_sha1
 
     def save(self, *args, **kwargs):
+        logger.error("hit save")
 
         if not self.info_hash:
             self.info_hash = self.generate_hash()

--- a/pivoteer/tasks.py
+++ b/pivoteer/tasks.py
@@ -224,6 +224,7 @@ def malware_samples(self, indicator, source):
 
 @app.task(bind=True)
 def google_safebrowsing(self, indicator):
+    print("hit")
     current_time = datetime.datetime.utcnow()
     safebrowsing_response = lookup_google_safe_browsing(indicator)
     safebrowsing_status = safebrowsing_response[0]
@@ -236,8 +237,11 @@ def google_safebrowsing(self, indicator):
                                        info=OrderedDict({"indicator": indicator,
                                                          "statusCode": safebrowsing_status,
                                                          "body": safebrowsing_body}))
-        record_entry.save()
+        print("before save")
+        if not record_entry.save():
+            logger.error("did not save safebrowsing")
     except Exception as e:
+        logger.error("kreger error")
         print(e)
 
 

--- a/tests/test_pivoteer.py
+++ b/tests/test_pivoteer.py
@@ -1,0 +1,190 @@
+import datetime, logging
+from celery import Celery
+from collections import OrderedDict
+from django.test import TestCase
+from pivoteer.models import IndicatorRecord, IndicatorManager
+from pivoteer.tasks import certificate_cen, domain_thc, ip_thc, domain_whois, ip_whois, domain_hosts, ip_hosts, passive_hosts, malware_samples, google_safebrowsing, totalhash_ip_domain_search, make_indicator_search_records
+
+app = Celery('RAPID')
+
+logger = logging.getLogger(None)
+
+
+class SimplisticTest(TestCase):
+
+    indicator = "foo.com"
+    current_time = datetime.datetime.utcnow()
+
+    def setUp(self):
+        print('In setUp()')
+        app.conf.update(CELERY_ALWAYS_EAGER=True)
+        app.conf.update(TEST_RUNNER = 'djcelery.contrib.test_runner.CeleryTestSuiteRunner')
+
+    def tearDown(self):
+        print('In tearDown()')
+
+    def test_safesearch_record_contents(self):
+        # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
+        google_safebrowsing.delay(self.indicator)
+
+        # Retreive records (return value is a QuerySet).
+        safebrowsing_records = IndicatorRecord.objects.safebrowsing_record(self.indicator)
+
+        # Validate that each field is included in the record.
+        # We must loop even though there is only one record because Django gives us a QuerySet.
+        for record in safebrowsing_records:
+            self.assertTrue("SB" in record.record_type)
+            self.assertTrue("GSB" in record.info_source)
+            self.assertEqual(self.current_time, record.info_date)
+            self.assertTrue("statusCode" in record.info)
+            self.assertTrue("indicator" in record.info)
+            self.assertTrue("body" in record.info)
+
+    def test_malware_record_contents(self):
+        # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
+        malware_samples.delay(self.indicator, "VTO")
+
+        # Retreive records (return value is a QuerySet).
+        malware_vto_records = IndicatorRecord.objects.malware_records(self.indicator)
+
+        # Validate that each field is included in the record.
+        # We must loop even though there is only one record because Django gives us a QuerySet.
+        for record in malware_vto_records:
+            self.assertTrue("MR" in record.record_type)
+            self.assertTrue("VTO" in record.info_source)
+            self.assertEqual(self.current_time, record.info_date)
+            self.assertTrue("md5" in record.info)
+            self.assertTrue("sha1" in record.info)
+            self.assertTrue("indicator" in record.info)
+            self.assertTrue("link" in record.info)
+
+    def test_certificate_cen_contents(self):
+        # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
+        certificate_cen.delay(self.indicator, "VTO")
+
+        # Retreive records (return value is a QuerySet).
+        certificate_cen_records = IndicatorRecord.objects.recent_cert(self.indicator)
+
+        # Validate that each field is included in the record.
+        # We must loop even though there is only one record because Django gives us a QuerySet.
+        for record in certificate_cen_records:
+            self.assertTrue("CE" in record.record_type)
+            self.assertTrue("CEN" in record.info_source)
+            self.assertEqual(self.current_time, record.info_date)
+            self.assertTrue("info" in record)
+
+    def test_domain_thc(self):
+        # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
+        domain_thc.delay(self.indicator)
+
+        # Retreive records (return value is a QuerySet).
+        domain_thc_records = IndicatorRecord.objects.recent_tc(self.indicator)
+
+        # Validate that each field is included in the record.
+        # We must loop even though there is only one record because Django gives us a QuerySet.
+        for record in domain_thc_records:
+            self.assertTrue("TR" in record.record_type)
+            self.assertTrue("THR" in record.info_source)
+            self.assertEqual(self.current_time, record.info_date)
+            self.assertTrue("info" in record)
+
+    def test_ip_thc(self):
+        # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
+        ip_thc.delay(self.indicator)
+
+        # Retreive records (return value is a QuerySet).
+        ip_thc_records = IndicatorRecord.objects.recent_tc(self.indicator)
+
+        # Validate that each field is included in the record.
+        # We must loop even though there is only one record because Django gives us a QuerySet.
+        for record in ip_thc_records:
+            self.assertTrue("TR" in record.record_type)
+            self.assertTrue("THR" in record.info_source)
+            self.assertEqual(self.current_time, record.info_date)
+            self.assertTrue("info" in record)
+
+    def test_domain_whois(self):
+        # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
+        domain_whois.delay(self.indicator)
+
+        # Retreive records (return value is a QuerySet).
+        domain_whois_records = IndicatorRecord.objects.whois_records(self.indicator)
+
+        # Validate that each field is included in the record.
+        # We must loop even though there is only one record because Django gives us a QuerySet.
+        for record in domain_whois_records:
+            self.assertTrue("WR" in record.record_type)
+            self.assertTrue("WIS" in record.info_source)
+            self.assertEqual(self.current_time, record.info_date)
+            self.assertTrue("info" in record)
+            self.assertTrue("domain" in record.info)
+            self.assertTrue("status" in record.info)
+            self.assertTrue("registrar" in record.info)
+            self.assertTrue("updated_date" in record.info)
+            self.assertTrue("expiration_date" in record.info)
+            self.assertTrue("nameservers" in record.info)
+            self.assertTrue("contacts" in record.info)
+
+    def test_ip_whois(self):
+        # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
+        ip_whois.delay(self.indicator)
+
+        # Retreive records (return value is a QuerySet).
+        ip_whois_records = IndicatorRecord.objects.whois_records(self.indicator)
+
+        # Validate that each field is included in the record.
+        # We must loop even though there is only one record because Django gives us a QuerySet.
+        for record in ip_whois_records:
+            self.assertTrue("WR" in record.record_type)
+            self.assertTrue("WIS" in record.info_source)
+            self.assertEqual(self.current_time, record.info_date)
+            self.assertTrue("info" in record)
+            self.assertTrue("query" in record.info)
+            self.assertTrue("asn" in record.info)
+            self.assertTrue("asn_registry" in record.info)
+            self.assertTrue("asn_country_code" in record.info)
+            self.assertTrue("asn_date" in record.info)
+            self.assertTrue("referral" in record.info)
+            self.assertTrue("dates" in record.info)
+
+
+    def test_domain_hosts(self):
+        # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
+        domain_hosts.delay(self.indicator)
+
+        # Retreive records (return value is a QuerySet).
+        domain_hosts_records = IndicatorRecord.objects.recent_hosts(self.indicator)
+
+        # Validate that each field is included in the record.
+        # We must loop even though there is only one record because Django gives us a QuerySet.
+        for record in domain_hosts_records:
+            self.assertTrue("HR" in record.record_type)
+            self.assertTrue("DNS" in record.info_source)
+            self.assertEqual(self.current_time, record.info_date)
+            self.assertTrue("info" in record)
+            self.assertTrue("geo_location" in record.info)
+            self.assertTrue("https_cert" in record.info)
+            self.assertTrue("ip" in record.info)
+
+    def test_ip_hosts(self):
+        # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
+        ip_hosts.delay(self.indicator)
+
+        # Retreive records (return value is a QuerySet).
+        ip_hosts_records = IndicatorRecord.objects.recent_hosts(self.indicator)
+
+        if not ip_hosts_records:
+            print("no good")
+
+        # Validate that each field is included in the record.
+        # We must loop even though there is only one record because Django gives us a QuerySet.
+        for record in ip_hosts_records:
+            self.assertTrue("HR" in record.record_type)
+            self.assertTrue("REX" in record.info_source)
+            self.assertEqual(self.current_time, record.info_date)
+            self.assertTrue("info" in record)
+            self.assertTrue("geo_location" in record.info)
+            self.assertTrue("htts_cert" in record.info)
+            self.assertTrue("ip" in record.info)
+
+    # def test_passive_hosts(self):

--- a/tests/test_pivoteer.py
+++ b/tests/test_pivoteer.py
@@ -25,17 +25,18 @@ class SimplisticTest(TestCase):
 
     def test_safesearch_record_contents(self):
         # Execute Celery task synchrounously using .delay(). This will store the record in the test DB.
-        google_safebrowsing.delay(self.indicator)
+        google_safebrowsing(self.indicator)
 
         # Retreive records (return value is a QuerySet).
         safebrowsing_records = IndicatorRecord.objects.safebrowsing_record(self.indicator)
+        self.assertGreater(safebrowsing_records.count(), 0)
 
         # Validate that each field is included in the record.
         # We must loop even though there is only one record because Django gives us a QuerySet.
         for record in safebrowsing_records:
             self.assertTrue("SB" in record.record_type)
             self.assertTrue("GSB" in record.info_source)
-            self.assertEqual(self.current_time, record.info_date)
+            self.assertGreater(datetime.datetime.utcnow(), record.info_date)
             self.assertTrue("statusCode" in record.info)
             self.assertTrue("indicator" in record.info)
             self.assertTrue("body" in record.info)


### PR DESCRIPTION
1. First is update manage.py to use local settings, not production settings. Not sure why this impacts DB saving, since db connection is in base.py, but switching to local allows the record to save for some reason

2. Second thing is removing the .delay() function wrapper, so that print() calls goes to stdout, rather than the celery logs. Makes it a little easier. This change cuts celery out of the loop completely, and the django app directly calls the google safesearch function.

3. * Not really related to the overall test harness stuff, but I updated the actual assertions for the safesearch test case. First assertion checks if anything comes back from the db, second assertion checks that the safesearch query happened before now. Without some timeshifting code, the time when the safesearch happens, and the time when the assertion executes will always be different. Not really useful checks in any case, but I didn't want to delete it without explanation.